### PR TITLE
Update default instance type to m4.xlarge

### DIFF
--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -30,7 +30,7 @@ variable "image_id" {
 
 variable "instance_type" {
   description = "Type of EC2 instance to be launched"
-  default     = "t3.micro"
+  default     = "m4.xlarge"
 }
 
 variable "create_service_role" {


### PR DESCRIPTION
## Summary
- Update default ECS instance type from `t3.micro` to `m4.xlarge`
- Provides increased compute capacity for ECS cluster workloads

## Test plan
- [ ] Verify Terraform plan shows the instance type change
- [ ] Deploy to dev environment and confirm instances launch with m4.xlarge

🤖 Generated with [Claude Code](https://claude.com/claude-code)